### PR TITLE
Added command for installing socat on OSX

### DIFF
--- a/hub/03-install-agent.md
+++ b/hub/03-install-agent.md
@@ -18,6 +18,7 @@ Install brew package manager
 brew update
 brew upgrade
 brew install wget
+brew install socat
 ```
 
 [Get and install](https://docs.docker.com/docker-for-mac/install/) Docker


### PR DESCRIPTION
Updated /hub/03-install-agent.md to include commands for installing socat on OSX.

Signed-off-by: Nagesh Subrahmanyam <nsubrah1@in.ibm.com>